### PR TITLE
remove istrue from if statement

### DIFF
--- a/src/wcall.jl
+++ b/src/wcall.jl
@@ -29,7 +29,7 @@ function wcall(head::AbstractString, args...; returnJulia=true,kwargs...)
 end
 wcall(head::AbstractString, args::Vararg{Mtypes}; returnJulia=true, kwargs...) = begin
     mathematica_result = weval(MathLink.WSymbol(head)(args...; kwargs...))
-    if istrue(returnJulia)
+    if returnJulia
         return mathematica_to_expr(mathematica_result)
     else
         return mathematica_result


### PR DESCRIPTION
I get the error ```UndefVarError: `istrue` not defined``` when calling wcall. I don't see why it should be there in the if-statement, so this PR removes it.