### PR TITLE
Updated handling of array and subscripted variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For example, Mathematica excels at solving complicated equations and differentia
 
 ## Installation
 
-To run SymbolicsMathLink.jl, both the [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) package and the [MathLink.jl](https://github.com/JuliaInterop/MathLink.jl) package must be installed **and configured**. That means you must have an active subscription to Mathematica or the free Wolfram Engine installed on your computer. See details in MathLink.jl for more information, but be aware that it takes some effort.
+To run SymbolicsMathLink.jl, both the [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) package and the [MathLink.jl](https://github.com/JuliaInterop/MathLink.jl) package must be installed **and configured**. That means you must have an active subscription to Mathematica or the free Wolfram Engine installed on your computer. See details in MathLink.jl for more information, but be aware that it can take some effort. Linux (or WSL) is strongly recommended.
 
 To install SymbolicsMathLink.jl, run the following command in the Julia REPL:
 

--- a/src/Header/Dictionaries.jl
+++ b/src/Header/Dictionaries.jl
@@ -152,5 +152,6 @@ const JULIA_FUNCTIONS_TO_MATHEMATICA = Dict(
     :besselk => "BesselK",
     :hankelh1 => "HankelH1",
     :hankelh2 => "HankelH2",
-    :zeta => "Zeta"
+    :zeta => "Zeta",
+    :getindex => "Subscript"
 )

--- a/src/Header/expr_to_mathematica.jl
+++ b/src/Header/expr_to_mathematica.jl
@@ -54,7 +54,7 @@ expr_to_mathematica_symbol_vector_checker(str::String,m::RegexMatch)=begin
     replacements=("₁"=>"1","₂"=>"2","₃"=>"3","₄"=>"4","₅"=>"5","₆"=>"6","₇"=>"7","₈"=>"8","₉"=>"9","₀"=>"0","ˏ"=>",")
     indices = split(replace(m[2],replacements...),",")
     indices = map(ind->parse(Int64, ind), indices)
-    m = MathLink.WSymbol("Subscript")(MathLink.WSymbol(m[1]), expr_to_mathematica.(indices)...)
+    m = MathLink.WSymbol("Subscript")(MathLink.WSymbol(m[1]*"ₛ"), expr_to_mathematica.(indices)...)
     m
 end
 expr_to_mathematica(symbol::Symbol)::MathLink.WTypes=begin

--- a/src/Header/mathematica_to_expr.jl
+++ b/src/Header/mathematica_to_expr.jl
@@ -42,8 +42,7 @@ mathematica_to_expr_differential_checker(head::MathLink.WSymbol,args::Vector)=be
     elseif head.name=="Subscript" && isa(args[1],MathLink.WSymbol)
         return mathematica_to_subscript_expr(args[1], args[2:end])
     elseif haskey(MATHEMATICA_TO_JULIA_FUNCTIONS, head.name)
-        stuff = mathematica_to_expr.(args)
-        return MATHEMATICA_TO_JULIA_FUNCTIONS[head.name](stuff...)
+        return MATHEMATICA_TO_JULIA_FUNCTIONS[head.name](mathematica_to_expr.(args)...)
     else
         m=match(r"Subscript\[\s*(\w+?),\s*(\d+(?:\s*,\s*\d+)*)\]",head.name)
         return mathematica_to_expr_vector_checker(head.name,args,m)

--- a/src/Header/mathematica_to_expr.jl
+++ b/src/Header/mathematica_to_expr.jl
@@ -6,8 +6,11 @@ mathematica_to_expr_vector_checker(head::AbstractString,args::Vector,::Nothing)=
 end
 mathematica_to_expr_vector_checker(head::AbstractString,args::Vector,m::RegexMatch)=begin
     varname=Symbol(m[1])
-    (vars,)=Symbolics.scalarize.(Symbolics.@variables $varname(mathematica_to_expr.(args)...)[1:parse(Int8,m[2])])
-    vars[parse(Int8,m[2])]
+    indices = map(s -> parse(Int8, s), split(replace(m[2]," "=>""), ",")) 
+    ranges = map(ind -> 1:ind, indices)
+    (vars,)=Symbolics.scalarize.(Symbolics.@variables $varname(mathematica_to_expr.(args)...)[ranges...])
+    indices = length(indices) == 1 ? indices[1] : indices
+    vars[indices...]
 end
 mathematica_to_expr_differential_checker(head::MathLink.WExpr,args::Vector)::Num=begin
     if head.head.head.name=="Derivative"
@@ -16,13 +19,24 @@ mathematica_to_expr_differential_checker(head::MathLink.WExpr,args::Vector)::Num
         throw(ArgumentError("Not a derivative: problem in mathematica_to_expr_differential_checker"))
     end
 end
+mathematica_to_subscript_expr(symb::MathLink.WSymbol,indices::Vector)=begin
+    ranges = map(ind -> 1:ind, indices)
+    varname = Symbol(symb)
+    (vars,)= Symbolics.scalarize.(Symbolics.@variables $varname[ranges...])
+    indices = length(indices) == 1 ? indices[1] : indices
+    vars[indices...]
+end
+
 mathematica_to_expr_differential_checker(head::MathLink.WSymbol,args::Vector)=begin
     if head.name=="Power" && isa(args[1],MathLink.WSymbol) && args[1].name=="E"
         return exp(mathematica_to_expr.(args[2:end])...)
+    elseif head.name=="Subscript" && isa(args[1],MathLink.WSymbol)
+        return mathematica_to_subscript_expr(args[1], args[2:end])
     elseif haskey(MATHEMATICA_TO_JULIA_FUNCTIONS, head.name)
-        return MATHEMATICA_TO_JULIA_FUNCTIONS[head.name](mathematica_to_expr.(args)...)
+        stuff = mathematica_to_expr.(args)
+        return MATHEMATICA_TO_JULIA_FUNCTIONS[head.name](stuff...)
     else
-        m=match(r"(.+)■([0-9]+)",head.name)
+        m=match(r"Subscript\[\s*(\w+?),\s*(\d+(?:\s*,\s*\d+)*)\]",head.name)
         return mathematica_to_expr_vector_checker(head.name,args,m)
         #return mathematica.head.name,getproperty.(mathematica.args,Ref(:name))...)
     end
@@ -32,7 +46,7 @@ function mathematica_to_expr(mathematica::MathLink.WExpr)
     """Converts a MathLink.WExpr to a Julia expression, checking if it's a differential"""
     mathematica_to_expr_differential_checker(mathematica.head,mathematica.args)
 end
-mathematica_to_expr(symbol::MathLink.WSymbol)=mathematica_to_expr(symbol,match(r"(.+)■([0-9]+)",symbol.name))
+mathematica_to_expr(symbol::MathLink.WSymbol)=mathematica_to_expr(symbol,match(r"Subscript\[\s*(\w+?),\s*(\d+(?:\s*,\s*\d+)*)\]",symbol.name))
 mathematica_to_expr(symbol::MathLink.WSymbol,::Nothing)=begin
     if haskey(MATHEMATICA_TO_JULIA_FUNCTIONS, symbol.name)
         return MATHEMATICA_TO_JULIA_FUNCTIONS[symbol.name]
@@ -42,8 +56,11 @@ mathematica_to_expr(symbol::MathLink.WSymbol,::Nothing)=begin
 end
 mathematica_to_expr(symbol::MathLink.WSymbol,m::RegexMatch)=begin
     varname=Symbol(m[1])
-    (vars,)=Symbolics.scalarize.(Symbolics.@variables $varname[1:parse(Int8,m[2])])
-    vars[parse(Int8,m[2])]
+    indices = map(s -> parse(Int8, s), split(replace(m[2]," "=>""), ",")) 
+    ranges = map(ind -> 1:ind, indices)
+    (vars,)=Symbolics.scalarize.(Symbolics.@variables $varname[ranges...])
+    indices = length(indices) == 1 ? indices[1] : indices
+    vars[indices...]
 end
 mathematica_to_expr(mathematica::MathLink.WReal)=mathematica_to_expr(weval(W"N"(mathematica)))
 mathematica_to_expr(num::T) where T<:Number=begin

--- a/src/Header/mathematica_to_expr.jl
+++ b/src/Header/mathematica_to_expr.jl
@@ -33,7 +33,7 @@ mathematica_to_subscript_expr(symb::AbstractString,indices::Vector)=begin
 end
 mathematica_to_subscript_expr(symb::MathLink.WSymbol,indices::Vector)=begin
     varstring = string(symb)
-    mathematica_to_subscript_expr(varstring)
+    mathematica_to_subscript_expr(varstring, indices)
 end
 
 mathematica_to_expr_differential_checker(head::MathLink.WSymbol,args::Vector)=begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,4 +65,11 @@ using Test
     expr = x^2 + y^2 + a
     replaced = SymbolicsMathLink.wcall("ReplaceAll", expr, rules)
     @test isequal(replaced, 1^2 + 2^2 + b)
+
+    # Test 16: Subscripted array elements round-trip through Mathematica conversion
+    @variables arr[1:2, 1:3]
+    sub_el = arr[2, 3]
+    mathematica_sub = SymbolicsMathLink.expr_to_mathematica(sub_el)
+    roundtripped = SymbolicsMathLink.mathematica_to_expr(mathematica_sub)
+    @test Symbolics.toexpr(roundtripped) == Symbolics.toexpr(sub_el)
 end


### PR DESCRIPTION
Currently, this package only supports transforming of variables with a single index and does not work when there are multiple indices for a variable. For example:
```julia
julia> using Symbolics, SymbolicsMathLink

julia> Symbolics.@variables a[1:2, 1:2] # OR a = Symbolics.variables(:a, 1:2)
1-element Vector{Symbolics.Arr{Num, 2}}:
 a[1:2,1:2]

julia> mathex = expr_to_mathematica(a[1,1])
W"a■1"

julia> symbex = mathematica_to_expr(mathex)
a[1]
```

Here, everything except the first index is lost. 

In this pull request, I have transformed the way in which subscripted indices are converted into mathematica. All subscripted indices are converted into the 'Subcript' function in mathematica, which naturally supported multiple indices. 
While converting back from mathematica, the subscript function is converted into an indexing operation. 
Subscripted variables are distinguished from array components by tagging it with a 'ₛ' at the end.
With the pull request, the example works as follows:
```julia
julia> using Symbolics, SymbolicsMathLink

julia> Symbolics.@variables a[1:2, 1:2] 
1-element Vector{Symbolics.Arr{Num, 2}}:
 a[1:2,1:2]

julia> mathex = expr_to_mathematica(a[1,1])
W`Subscript[a, 1, 1]`

julia> symbex = mathematica_to_expr(mathex)
a[1, 1]


julia> b = Symbolics.variables(:b, 1:2, 1:2)
2×2 Matrix{Num}:
 b₁ˏ₁  b₁ˏ₂
 b₂ˏ₁  b₂ˏ₂

julia> mathex = expr_to_mathematica(b[2,2])
W`Subscript[bₛ, 2, 2]`

julia> symbex = mathematica_to_expr(mathex)
b₂ˏ₂
```

Note: I was not completely sure about the control flow and purpose of all of the functions, so there might be some redundant or unnecessary code still remaining. 